### PR TITLE
android: initialize aosp-{path,board-name} to nil

### DIFF
--- a/dctrl-adb.el
+++ b/dctrl-adb.el
@@ -33,6 +33,9 @@
 
 (defvar adb-push-file-history '())
 
+(defvar aosp-path nil)
+(defvar aosp-board-name nil)
+
 (defun dctrl-adb-run (&rest args)
   (dctrl-run-process
    (nconc (list adb-exec) (if dctrl-automatic-mode

--- a/dctrl-fastboot.el
+++ b/dctrl-fastboot.el
@@ -32,6 +32,9 @@
   "The default fastboot program."
   :group 'device-control)
 
+(defvar aosp-path nil)
+(defvar aosp-board-name nil)
+
 (defun dctrl-fsb-run (&rest args)
   (dctrl-run-process
    (nconc (list fastboot-program) (if dctrl-automatic-mode


### PR DESCRIPTION
If aosp-path or aosp-board-name is undefined,
(dctrl-adb-aosp-out-dir) will fail with the following error:

funcall-interactively: Symbol’s value as variable is void:
adb-aosp-out-dir

Fix it by initializing aosp-{path,board-name} to nil

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>