### PR TITLE
fastboot: implement fastboot update command

### DIFF
--- a/dctrl-fastboot.el
+++ b/dctrl-fastboot.el
@@ -106,6 +106,11 @@
       (with-untramped-file ramdisk
 	(dctrl-fsb-run "flash:raw" kernel ramdisk)))))
 
+(defun dctrl-fsb-action-update (&optional zipfile)
+  (let ((zipfile (dctrl-fsb-read-file "Zipfile" zipfile "img.zip")))
+    (with-untramped-file zipfile
+      (dctrl-fsb-run "update" zipfile))))
+
 (defun dctrl-fsb-action-continue ()
   (dctrl-fsb-run "continue"))
 


### PR DESCRIPTION
Fastboot update reflashes boot.img, recovery.img and system.img

It is widely used to flash Pixel devices available here:
  https://developers.google.com/android/images

Implement fastboot update command as `update`.

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>