### PR TITLE
notifications: only enable if emacs has dbus support

### DIFF
--- a/device-control.el
+++ b/device-control.el
@@ -139,13 +139,14 @@ its functions available to device control."
 (defun dctrl-headline-msg (msg)
   (when dctrl-prev-notif-id
     (notifications-close-notification dctrl-prev-notif-id))
-  (setq dctrl-prev-notif-id
-	(apply 'notifications-notify
-	       :app-name "DeviceControl"
-	       :title "Device control"
-	       :body msg
-	       (when dctrl-icon
-		 (list :app-icon dctrl-icon))))
+  (when (and (featurep 'dbusbind) (notifications-get-server-information))
+    (setq dctrl-prev-notif-id
+          (apply 'notifications-notify
+                 :app-name "DeviceControl"
+                 :title "Device control"
+                 :body msg
+                 (when dctrl-icon
+               (list :app-icon dctrl-icon)))))
   (dctrl-msg msg 'success))
 
 (defun dctrl-error (msg)


### PR DESCRIPTION
When using the device-control module on emacs with no dbus
support, the module crashes with the following error:

 dbus-call-method: peculiar error: "Emacs not compiled with dbus support"

This error is shown each time we call a notifications-* function.

Only use notifications if dbus support is enabled for emacs.

This fixes #4

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>
Signed-off-by: Jeremy Compostella <jeremy.compostella@gmail.com>