### PR TITLE
fastboot: add "wipe" (-w) action

### DIFF
--- a/dctrl-fastboot.el
+++ b/dctrl-fastboot.el
@@ -115,6 +115,9 @@
 (defun dctrl-fsb-action-reboot-bootloader ()
   (dctrl-fsb-run "reboot-bootloader"))
 
+(defun dctrl-fsb-action-wipe ()
+  (dctrl-fsb-run "-w"))
+
 (defun dctrl-fsb-connected-p ()
   (let ((devices (dctrl-fsb-guess-device-names)))
     (if dctrl-automatic-mode


### PR DESCRIPTION
fastboot -w wipes userdata and cache.
It also formats the partitions if the filesystem permits it.

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>